### PR TITLE
hotfix: various bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Keep in mind that loading large video files may take a few seconds.
 
 - **Adopting Predictions**:
     - Click on a block in the AI timeline and then on 'adopt' to apply the prediction to the ground truth timeline.
+    - This is the active learning part: based on the confidence the model has (visualised by red-green gradient on Ci timeline), users are adviced to annotate the most uncertain parts first and can decide when to stop annotating.
     - **Note**: This action overrides any overlapping user-annotated blocks, so use it cautiously.
 
 - **Model Training Constraints**:

--- a/app/app.py
+++ b/app/app.py
@@ -110,7 +110,7 @@ def process_blocks():
     # print('model:')
     # print(model)
     results = modelfunc.run_model(blocks, settings, model=model, unlabeled_df=df, label_mapping=label_mapping, stored_sequences=stored_sequences)
-    result_list, settings, model, prediction_df, label_mapping, df, padded_sequences, padded_labels = results
+    result_list, settings, model, prediction_df, label_mapping, padded_sequences, padded_labels = results
 
     print('Received blocks from GT:', blocks)
     print('Requested epochs:', epochs)
@@ -143,8 +143,21 @@ def process_blocks():
 @app.route('/data/uploads', methods=['POST'])
 def handle_upload():
     global df
+    global label_mapping
+    global model
+    global stored_sequences
     global settings
     global prediction_df
+
+    label_mapping = {}
+    stored_sequences = None
+    model = None
+    settings = {}
+
+    if 'video_path' in settings:
+        del settings['video_path']
+    if 'imu_path' in settings:
+        del settings['imu_path']
 
     # Handle file uploads
     mp4_file = request.files.get('mp4-upload')
@@ -231,6 +244,12 @@ def upload_files():
     global label_mapping
     global settings
     global stored_sequences
+
+    if 'video_path' in settings:
+        del settings['video_path']
+    if 'imu_path' in settings:
+        del settings['imu_path']
+
     model_file = request.files.get('model_upload')
     video_file = request.files.get('mp4_upload')
     csv_file = request.files.get('csv_upload')
@@ -248,6 +267,10 @@ def upload_files():
         settings['model_path'] = str(model_path)
         try:
             model, label_mapping, settings, stored_sequences = load_model(str(model_path))
+            if 'video_path' in settings:
+                del settings['video_path']
+            if 'imu_path' in settings:
+                del settings['imu_path']
         except Exception as e:
             flash('Error with uploaded zip')
             print(e)

--- a/app/app.py
+++ b/app/app.py
@@ -111,6 +111,7 @@ def process_blocks():
     # print(model)
     results = modelfunc.run_model(blocks, settings, model=model, unlabeled_df=df, label_mapping=label_mapping, stored_sequences=stored_sequences)
     result_list, settings, model, prediction_df, label_mapping, padded_sequences, padded_labels = results
+    
 
     print('Received blocks from GT:', blocks)
     print('Requested epochs:', epochs)

--- a/app/static/js/predict.js
+++ b/app/static/js/predict.js
@@ -22,6 +22,8 @@ let activeBlockId = null;
 // Selected AI block
 let selectedAIBlockId = null;
 
+let colorIndex = -1;
+
 /********************************************************************
  * DOM REFERENCES
  ********************************************************************/
@@ -47,7 +49,7 @@ const timelinesContainer = document.querySelector('.timelines-container');
 const FPS = 60000 / 1001;
 
 // 1 px = 15 frames
-const FRAMES_PER_PIXEL = 15;
+const FRAMES_PER_PIXEL = 5;
 
 // We'll ensure timeline width is at least some fallback
 const MIN_TIMELINE_WIDTH = 1600;
@@ -60,6 +62,31 @@ const DEFAULT_BLOCK_WIDTH_PX = 70;
  ********************************************************************/
 video.addEventListener('loadedmetadata', () => {
   initTimelines();
+
+  fetch('/get_labels')
+  .then(response => response.json())
+  .then(data => {
+    for (const label of data.labels) {
+      colorIndex++;
+      const color = getRandomColor(colorIndex);
+      const labelId = Date.now() + '-' + Math.random();
+      const labelObj = { id: labelId, name: label, color };
+    
+      labels.push(labelObj);
+    
+      const button = document.createElement('button');
+      button.classList.add('label-button');
+      button.style.backgroundColor = color;
+      button.innerText = label;
+  
+    
+      labelList.appendChild(button);
+    }
+    console.log('Labels fetched dynamically:', data.labels);
+  })
+  .catch(error => {
+    console.error('Error fetching labels:', error);
+  });
 });
 
 function initTimelines() {
@@ -365,13 +392,31 @@ function createBlock(label) {
 /********************************************************************
  * LABELS
  ********************************************************************/
-function getRandomColor() {
-  const letters = '0123456789ABCDEF';
-  let color = '#';
-  for (let i = 0; i < 6; i++) {
-    color += letters[Math.floor(Math.random() * 16)];
+function getRandomColor(index = null) {
+  const palette = [
+    '#c81d25',    
+    '#00FFFF',    
+    '#2fff00',    
+    '#0000FF',    
+    '#ffe74c',    
+    '#FF00FF',    
+    '#FFA500',    
+    '#800080',    
+    '#008000',    
+    '#A52A2A',    
+    '#4B0082',    
+    '#FA8072',    
+    '#D2691E',    
+    '#20B2AA',     
+    '#731500',
+    '#ff206e'
+];
+  
+  if (index !== null && index >= 0 && index < palette.length) {
+    return palette[index];
   }
-  return color;
+  
+  return palette[Math.floor(Math.random() * palette.length)];
 }
 
 addLabelButton.addEventListener('click', () => {

--- a/app/templates/predict.html
+++ b/app/templates/predict.html
@@ -65,7 +65,7 @@
           <!-- Timelines container: horizontally scrollable if wide -->
           <div class="timelines-container">
             <!-- 1) Ground Truth (editable) -->
-            <div class="timeline-row hidden">
+            <div class="timeline-row">
               <div class="timeline-label">GT</div>
               <div id="groundTruthTimeline" class="timeline-container">
                 <div class="playhead"></div>

--- a/app/templates/predict.html
+++ b/app/templates/predict.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <title>Predict and Detect Anomalies</title>
   <link rel="stylesheet" href="/static/css/training.css">
+  <style>
+      .label-button:hover {
+    opacity: 1 !important;
+  }
+    .label-button {
+      cursor: auto !important;
+    }
+  </style>
   <script type="module" src="/static/js/predict.js" defer></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/plotly.js/2.24.2/plotly.min.js"></script>
 </head>
@@ -127,7 +135,6 @@
     function updatePlot() {
         const xAxis = document.getElementById('xAxis').value;
         const yAxis = document.getElementById('yAxis').value;
-        // fetch(`/get_plot_data?x=${xAxis}&y=${yAxis}&ci=${document.querySelector('#anomalyThreshold').value}`)
         console.log('sending data...')
         fetch('/get_plot_data', {
             method: 'POST',

--- a/src/model.py
+++ b/src/model.py
@@ -235,8 +235,6 @@ def run_model(labeled_frames, settings, model=None, unlabeled_df=None, label_map
     padded_sequences, padded_labels = sequencing.get_filtered_sequences_and_labels(copy.deepcopy(sequences))
     print(padded_sequences.shape)
     print(padded_labels.shape)
-    if stored_sequences != None:
-        print(stored_sequences.shape)
     all_sequences = sequencing.save_used_data(padded_sequences, padded_labels, stored_sequences)
     print(all_sequences.shape)
     train_sequences, train_labels = all_sequences[:,:,0:6], all_sequences[:,:,6:]

--- a/src/model.py
+++ b/src/model.py
@@ -186,7 +186,7 @@ def predict(model, sequences, label_mapping):
    
 
     # Combine sequences, predicted labels, and confidence scores into a DataFrame
-    prediction_data = sequencing.combine_and_restitch_sequences(sequences, predicted_labels, confidence_scores)
+    prediction_data = sequencing.combine_and_restitch_sequences(copy.deepcopy(sequences), predicted_labels, confidence_scores)
     prediction_df = pd.DataFrame(prediction_data, columns=['TIMESTAMP', 'ACCL_x', 'ACCL_y', 'ACCL_z', 'GYRO_x', 'GYRO_y', 'GYRO_z', 'FRAME_INDEX', 'LABEL', 'CONFIDENCE']).astype({'CONFIDENCE': np.float64})
 
     result_list = []
@@ -204,7 +204,7 @@ def predict(model, sequences, label_mapping):
 
 def run_model(labeled_frames, settings, model=None, unlabeled_df=None, label_mapping={}, stored_sequences=None):
     # check if labels are the same
-    unique_labels = sorted(set(item["label"] for item in labeled_frames))
+    unique_labels = set(item["label"] for item in labeled_frames)
     if not set(unique_labels).issubset(set(label_mapping.keys())):
         settings["from_scratch"] = True
         for label in unique_labels:
@@ -277,8 +277,8 @@ def run_model(labeled_frames, settings, model=None, unlabeled_df=None, label_map
 
     prediction_df, result_list = predict(model, sequences, label_mapping)
     settings["from_scratch"] = False
-
-    return result_list, settings, model, prediction_df, label_mapping, unlabeled_df, padded_sequences, padded_labels
+    print(f'lenth of result_list: {len(result_list)}')
+    return result_list, settings, model, prediction_df, label_mapping, padded_sequences, padded_labels
 
 
 def model_predict(df, settings, model, label_mapping):
@@ -327,12 +327,6 @@ def load_model(file_path="models/model.zip"):
     # Extract the zip file
     with zipfile.ZipFile(file_path, "r") as zipf:
         zipf.extractall()
-    
-    # Load model and other components
-    model = tf.keras.models.load_model("model.h5", compile=False)
-    optimizer = tf.keras.optimizers.Adam(learning_rate=0.0001, decay=None)
-    model.compile(optimizer=optimizer, loss="categorical_crossentropy", metrics=["accuracy"])
-    model.summary()
 
     with open("label_mapping.pkl", "rb") as f:
         label_mapping = pickle.load(f)
@@ -340,6 +334,12 @@ def load_model(file_path="models/model.zip"):
         settings = pickle.load(f)
     with open("stored_sequences.pkl", "rb") as f:
         stored_sequences = pickle.load(f)
+
+    # Load model and other components
+    model = tf.keras.models.load_model("model.h5", compile=False)
+    optimizer = tf.keras.optimizers.Adam(learning_rate=settings['learning_rate'], decay=None)
+    model.compile(optimizer=optimizer, loss="categorical_crossentropy", metrics=["accuracy"])
+    model.summary()
     
     # Remove extracted files
     os.remove("model.h5")

--- a/src/model.py
+++ b/src/model.py
@@ -283,6 +283,8 @@ def run_model(labeled_frames, settings, model=None, unlabeled_df=None, label_map
 
 def model_predict(df, settings, model, label_mapping):
     n_labels = len(label_mapping)
+    df.dropna(subset=["FRAME_INDEX"], inplace=True)
+    df["FRAME_INDEX"] = df["FRAME_INDEX"].astype(int)
 
     sequences = sequencing.create_sequence(df, settings["overlap"], settings["length"])
     prediction_df, result_list = predict(model, sequences, label_mapping)

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -43,7 +43,7 @@ def prepare_data(df: pd.DataFrame, confidence_threshold: float = 0, sample_ratio
 
     if sample_ratio > 0 and sample_ratio < 1:
         original_df = principal_df.copy()
-        sampled_df = original_df.groupby('COLOUR', group_keys=False).apply(
+        sampled_df = original_df.groupby('COLOUR', group_keys=False, observed=False).apply(
             lambda x: x.sample(frac=sample_ratio)
         )
         principal_df = sampled_df


### PR DESCRIPTION
## Summary

- Fixes bug where when loading the model in `src.model.load_model`, the `learning_rate` for the Adam optimiser was hardcoded to `0.0001`. It now uses the correct value from the loaded settings.
- Fixes bug where the global variables `model`, `label_mapping`, and `stored_sequences` were not reset after training a model. If you selected 'Create New Model' in `welcome_tab.html` a second time, after having already trained a model, it would use the state for the old model.
- Fixes bug where when training a model on video + IMU CSV and then retraining the model on only a new IMU video, it would use the IMU telemetry from the old video as `settings['imu_path']` was never reset, triggering the `if 'video_path' in settings and 'imu_path' in settings:` check instead of `if 'video_path' in settings and not 'imu_path' in settings:`.
- Fixes: #31
- Fixes: #32
- Fixes inconsistent timeline scaling. The predict tab now also uses a 5 frames per pixel ratio.
